### PR TITLE
Adding security costs prior to inauguration

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -7,7 +7,10 @@ const baselineCosts: Array<number> = [
   3000000,
   // Eric Trump's Uruguay trip
   // http://thehill.com/homenews/administration/317863-eric-trump-uruguay-trip-cost-taxpayers-98k-report
-  98000
+  98000,
+  // Total costs for security before Inauguration
+  // http://nymag.com/daily/intelligencer/2017/01/nyc-trump-bill-usd37-4-million-from-election-to-inauguration.html
+  37400000
 ];
 
 // All individual costs added to a single value:


### PR DESCRIPTION
Adding a flat cost of $37,400,000.00 for security prior to Inauguration Day:

http://nymag.com/daily/intelligencer/2017/01/nyc-trump-bill-usd37-4-million-from-election-to-inauguration.html

Tweet that included this data:

https://twitter.com/trumptaxme/status/828692219402059776